### PR TITLE
PROPOSAL: PR Template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,24 @@
+# Description
+
+<!--- Please include a summary of the changes and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
+
+<!--- Please delete options that are not relevant. -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+Fixes # (link to Jira ticket/Pivotal tracker): 
+
+# How Has This Been Tested?
+<!--- Please describe the tests that you ran to verify your changes. Add the relevant link if any. Provide instructions for how to test/repo. Please also list any relevant details for your test configuration -->
+- [ ] Storybook deploy preview
+* Link: 
+- [ ] Site deploy preview
+* Link: 
+## How to test / reproduce (if necessary)
+
+# Screenshots / Gifs
+
+# Checklist:
+Refer to these guidelines: https://github.com/RateGravity/best-practices/blob/master/best-practices/git.md
+- [ ] My code follows the style guidelines of this project: https://github.com/RateGravity/best-practices
+- [ ] I have commented all of my functions and all my variables are descriptively named
+- [ ] I have made corresponding changes to the documentation


### PR DESCRIPTION
Here is a first proposal for a generic template (or variant of) that we could use on our repos in the future.

It is written in markdown so should be easy to edit.

Moved to `.github` -> making it a default file. 
Old conversation: https://github.com/RateGravity/best-practices/pull/57